### PR TITLE
related_query_name for permissions field

### DIFF
--- a/django_group_model/models.py
+++ b/django_group_model/models.py
@@ -18,6 +18,7 @@ class AbstractGroup(models.Model):
         verbose_name=_("permissions"),
         blank=True,
         related_name=permissions_related_name,
+        related_query_name="group",
     )
 
     objects = GroupManager()


### PR DESCRIPTION
The permissions field in AbstractGroup model must have related_query_name as "group".
```
class AbstractGroup(models.Model):
    name = models.CharField(_("name"), max_length=150, unique=True)
    permissions = models.ManyToManyField(
        Permission,
        verbose_name=_("permissions"),
        blank=True,
        related_name="custom_group",
        related_query_name="group",
    )
    ...
```
without this related_query_name, functions as get_group_permissions(), get_all_permissions() and permission_required decorator return error.